### PR TITLE
Remove call to multiprocessing. Fixes issue #422.

### DIFF
--- a/pymode/rope.py
+++ b/pymode/rope.py
@@ -409,12 +409,7 @@ class RopeContext(object):
                 importer.generate_modules_cache(modules)
             importer.project.sync()
 
-        sys.stdout, stdout_ = StringIO(), sys.stdout
-        sys.stderr, stderr_ = StringIO(), sys.stderr
-        process = multiprocessing.Process(target=_update_cache, args=(
-            self.importer, modules))
-        process.start()
-        sys.stdout, sys.stderr = stdout_, stderr_
+        _update_cache(self.importer, modules)
 
 
 class ProgressHandler(object):


### PR DESCRIPTION
Unless someone wants to autoimport all of the standard modules, removing this multiprocessing process shouldn't result in any performance loss. I did not find any difference and, as far as I can tell, the python-rope/ropevim implementation does not use multiprocessing either.

If someone still really wants multiprocessing in this instance, there are some other possible workarounds so as to not leave Windows users out in the cold, though I haven't thought of any that aren't ugly. As far as I can tell, the rope objects being used are not pickleable, and there's not much to be done there.