### PR TITLE
Don't force indentation to be 0 for lines not starting with whitespace

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -133,10 +133,6 @@ fun! pymode#folding#expr(lnum) "{{{
         endif
     endif
 
-    if indent == 0
-        return 0
-    endif
-
     return '='
 
 endfunction "}}}


### PR DESCRIPTION
Some docstrings/code parts use line continuation with zero whitespace on the
following line. In this case we should accept the previous lines indentation
instead of forcing the indentation to be zero.