### PR TITLE
Don't skip a line when the first docstring contains text

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -18,7 +18,7 @@ fun! pymode#folding#text() " {{{
     while getline(fs) !~ s:def_regex && getline(fs) !~ s:doc_begin_regex
         let fs = nextnonblank(fs + 1)
     endwhile
-    if getline(fs) =~ s:doc_begin_regex
+    if getline(fs) =~ s:doc_end_regex && getline(fs) =~ s:doc_begin_regex
         let fs = nextnonblank(fs + 1)
     endif
     let line = getline(fs)


### PR DESCRIPTION
According to [pep257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings), "The summary line may be on the same line as the opening quotes or on the next line." This PR will always show the summary line in a fold even if it is on the same line as the opening quotes.