### PR TITLE
Don't fold single line def

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -50,6 +50,10 @@ fun! pymode#folding#expr(lnum) "{{{
     endif
 
     if line =~ s:def_regex
+        " single line def
+        if indent(a:lnum) >= indent(a:lnum+1)
+            return '='
+        endif
         " Check if last decorator is before the last def
         let decorated = 0
         let lnum = a:lnum - 1


### PR DESCRIPTION
Simply checks whether the next line is more indented than the line
matching def_regex and if it's not don't increase the fold level.

Avoids an issue where 
```python
def rev(x): return reverse(x)
if something:
  def rev(x): return x
```
gets folded to
```python
def rev(x): return reverse(x)
```
not showing the rest of the code.