### PR TITLE
fix placement of pymode_options help description

### DIFF
--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -98,10 +98,6 @@ Setup default python options                                *'g:pymode_options'*
 >
     let g:pymode_options = 1
 
-Setup max line length                       *'g:pymode_options_max_line_length'*
->
-    let g:pymode_options_max_line_length = 79
-
 If this option is set to 1, pymode will enable the following options for
 python buffers: >
 
@@ -114,6 +110,10 @@ python buffers: >
     setlocal textwidth=79
     setlocal commentstring=#%s
     setlocal define=^\s*\\(def\\\\|class\\)
+
+Setup max line length                       *'g:pymode_options_max_line_length'*
+>
+    let g:pymode_options_max_line_length = 79
 
 Enable colorcolumn display at max_line_length   *'g:pymode_options_colorcolumn'*
 >


### PR DESCRIPTION
I'm new to python-mode and reading the help, it looked to me like the details of `let g:python_mode` help description were out of place.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/klen/python-mode/542)
<!-- Reviewable:end -->
