### PR TITLE
Skip doctest regions when searching for open pairs

### DIFF
--- a/autoload/pymode/indent.vim
+++ b/autoload/pymode/indent.vim
@@ -110,7 +110,7 @@ function! s:SearchParensPair() " {{{
     " Skip strings and comments and don't look too far
     let skip = "line('.') < " . (line - 50) . " ? dummy :" .
                 \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? ' .
-                \ '"string\\|comment"'
+                \ '"string\\|comment\\|doctest"'
 
     " Search for parentheses
     call cursor(line, col)


### PR DESCRIPTION
Doctests should be treated the same as strings/comments when searching for open pairs.

Before this change:
```python
class Foo:

    """
    >>> print '{ { }'
    { { }
    """

     def __init__(self):
     pass
```
After this change (correct indent of 'pass'):
```python
class Foo:

    """
    >>> print '{ { }'
    { { }
    """

     def __init__(self):
         pass
```