### PR TITLE
removing misstype

### DIFF
--- a/doc/pymode.txt
+++ b/doc/pymode.txt
@@ -443,7 +443,7 @@ imported) from project                              *'g:pymode_rope_autoimport'*
 
 Load modules to autoimport by default       *'g:pymode_rope_autoimport_modules'*
 >
-    let g:pymode_rope_autoimport_modules = ['os', 'shutil', 'datetime'])
+    let g:pymode_rope_autoimport_modules = ['os', 'shutil', 'datetime']
 
 Offer to unresolved import object after completion.
 >


### PR DESCRIPTION
Hello,  I noticed an unwanted ')' in documentation. 
