### PR TITLE
Highlight comments inside class/function arg lists

### DIFF
--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -80,13 +80,13 @@ endif
     syn match pythonFunction "\%(\%(def\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars
     syn region pythonVars start="(" skip=+\(".*"\|'.*'\)+ end=")" contained contains=pythonParameters transparent keepend
     syn match pythonParameters "[^,]*" contained contains=pythonParam skipwhite
-    syn match pythonParam "[^,]*" contained contains=pythonExtraOperator,pythonLambdaExpr,pythonBuiltinObj,pythonBuiltinType,pythonConstant,pythonString,pythonNumber,pythonBrackets,pythonSelf skipwhite
+    syn match pythonParam "[^,]*" contained contains=pythonExtraOperator,pythonLambdaExpr,pythonBuiltinObj,pythonBuiltinType,pythonConstant,pythonString,pythonNumber,pythonBrackets,pythonSelf,pythonComment skipwhite
     syn match pythonBrackets "{[(|)]}" contained skipwhite
 
     syn keyword pythonStatement class nextgroup=pythonClass skipwhite
     syn match pythonClass "\%(\%(class\s\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonClassVars
     syn region pythonClassVars start="(" end=")" contained contains=pythonClassParameters transparent keepend
-    syn match pythonClassParameters "[^,\*]*" contained contains=pythonBuiltin,pythonBuiltinObj,pythonBuiltinType,pythonExtraOperatorpythonStatement,pythonBrackets,pythonString skipwhite
+    syn match pythonClassParameters "[^,\*]*" contained contains=pythonBuiltin,pythonBuiltinObj,pythonBuiltinType,pythonExtraOperatorpythonStatement,pythonBrackets,pythonString,pythonComment skipwhite
 
     syn keyword pythonRepeat        for while
     syn keyword pythonConditional   if elif else


### PR DESCRIPTION
Comments are allowed in function argument and class parameter lists so they should be highlighted correctly. Git's markup language gets it half right:

```python
class Foo(a,  # blah
          b,  # blah
          ):
    pass


def bar(a=None,  # blah
        b=0,     # blah
        ):
    pass
```

For a prominent example of a function with comments in the argument list, see `matplotlib.figure.Figure`:
```python
class Figure(Artist):

    """
    ...
    """

    def __init__(self,
                 figsize=None,  # defaults to rc figure.figsize
                 dpi=None,  # defaults to rc figure.dpi
                 facecolor=None,  # defaults to rc figure.facecolor
                 edgecolor=None,  # defaults to rc figure.edgecolor
                 linewidth=0.0,  # the default linewidth of the frame
                 frameon=None,  # whether or not to draw the figure frame
                 subplotpars=None,  # default to rc
                 tight_layout=None,  # default to rc figure.autolayout
                 ):
        ...
```