### PR TITLE
Add Python documentation vertical display option

### DIFF
--- a/autoload/pymode/doc.vim
+++ b/autoload/pymode/doc.vim
@@ -29,6 +29,9 @@ fun! pymode#doc#show(word) "{{{
     setlocal nomodifiable
     setlocal nomodified
     setlocal filetype=rst
+    if g:pymode_doc_vertical
+        wincmd L
+    endif
     wincmd p
 
 endfunction "}}}

--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -52,6 +52,9 @@ call pymode#default("g:pymode_options", 1)
 call pymode#default("g:pymode_options_max_line_length", 80)
 call pymode#default("g:pymode_options_colorcolumn", 1)
 
+" Enable/disable vertical display of python documentation
+call pymode#default("g:pymode_doc_vertical", 0)
+
 " Minimal height of pymode quickfix window
 call pymode#default('g:pymode_quickfix_maxheight', 6)
 


### PR DESCRIPTION
Added an option to display Python docs in vertical windows.

To enable the option, user needs to modify her .vimrc file as follows:
```vim
let pymode_doc_vertical = 1
```
