### PR TITLE
g:pymode_trim_whitespaces = 0 was ignored.

### DIFF
--- a/autoload/pymode.vim
+++ b/autoload/pymode.vim
@@ -76,9 +76,11 @@ endfunction "}}}
 
 " DESC: Remove unused whitespaces
 fun! pymode#trim_whitespaces() "{{{
-    let cursor_pos = getpos('.')
-    silent! %s/\s\+$//
-    call setpos('.', cursor_pos)
+    if g:pymode_trim_whitespaces
+        let cursor_pos = getpos('.')
+        silent! %s/\s\+$//
+        call setpos('.', cursor_pos)
+    endif
 endfunction "}}}
 
 


### PR DESCRIPTION
* Added condition to the trim function itself.