### PR TITLE
Fix folding after blank line in class/def

### DIFF
--- a/autoload/pymode/folding.vim
+++ b/autoload/pymode/folding.vim
@@ -51,7 +51,7 @@ fun! pymode#folding#expr(lnum) "{{{
 
     if line =~ s:def_regex
         " single line def
-        if indent(a:lnum) >= indent(a:lnum+1)
+        if indent(a:lnum) >= indent(a:lnum+1) && getline(prevnonblank(a:lnum)) !~ ':\s*$'
             return '='
         endif
         " Check if last decorator is before the last def


### PR DESCRIPTION
This change caused a regression in folding: https://github.com/klen/python-mode/pull/534

If there is a blank line between a `class`/`def` statement, a fold won't be created. For example, the following folds into one line (`class Foo(object):`) before the change but not after:

```python
class Foo(object):

    """Description."""

    def __init__(self):
        pass
```