### PR TITLE
Fix `Undefined variable: b:pymode_modified` error when regeneration of rope project isn't wanted

### DIFF
--- a/autoload/pymode.vim
+++ b/autoload/pymode.vim
@@ -109,7 +109,7 @@ endfunction "}}}
 
 fun! pymode#buffer_pre_write() "{{{
     let b:pymode_modified = &modified
-endfunction
+endfunction "}}}
 
 fun! pymode#buffer_post_write() "{{{
     if g:pymode_rope

--- a/autoload/pymode.vim
+++ b/autoload/pymode.vim
@@ -113,7 +113,7 @@ endfunction "}}}
 
 fun! pymode#buffer_post_write() "{{{
     if g:pymode_rope
-        if b:pymode_modified && g:pymode_rope_regenerate_on_write
+        if g:pymode_rope_regenerate_on_write && b:pymode_modified
             call pymode#debug('regenerate')
             call pymode#rope#regenerate()
         endif


### PR DESCRIPTION
This avoids accessing the `b:python_modified` var, which under some circumstances won't be set, which results in the following error:

    Error detected while processing function pymode#buffer_post_write:
    line    2:
    E121: Undefined variable: b:pymode_modified
    E15: Invalid expression: b:pymode_modified && g:pymode_rope_regenerate_on_write

**Note:** this does not address the core issue with why `b:pymode_modified` is unset in the first place, but this avoids that being a problem if `g:python_rope_regenerate_on_write` is not wanted anyway.