### PR TITLE
Make encoding regexp less strict

### DIFF
--- a/pymode/libs3/rope/base/fscommands.py
+++ b/pymode/libs3/rope/base/fscommands.py
@@ -242,7 +242,7 @@ def read_str_coding(source):
     if not isinstance(source, str):
         source = source.decode("utf-8", "ignore")
     #TODO: change it to precompiled version
-    mex = re.search("\-\*\-\s+coding:\s+(.*?)\s+\-\*\-", source)
+    mex = re.search("\-\*\-\s+coding:\s*(.*?)\s+\-\*\-", source)
     if mex:
         return mex.group(1)
     return "utf-8"


### PR DESCRIPTION
Make the encoding detection regexp less strict so that it will detect the encoding of files
that do not have a space between the "coding:" statement and the encoding value.

Example: https://github.com/dateutil/dateutil/blob/master/dateutil/parser.py