### PR TITLE
Support for python 3.5 async/await keywords

### DIFF
--- a/plugin/pymode.vim
+++ b/plugin/pymode.vim
@@ -39,7 +39,7 @@ call pymode#default("g:pymode_folding", 1)
 " Maximum file length to check for nested class/def statements
 call pymode#default("g:pymode_folding_nest_limit", 1000)
 " Change for folding customization (by example enable fold for 'if', 'for')
-call pymode#default("g:pymode_folding_regex", '^\s*\%(class\|def\) \w\+')
+call pymode#default("g:pymode_folding_regex", '^\s*\%(class\|def\|async\s\+def\) \w\+')
 
 " Enable/disable python motion operators
 call pymode#default("g:pymode_motion", 1)

--- a/syntax/python.vim
+++ b/syntax/python.vim
@@ -75,6 +75,7 @@ endif
     syn keyword pythonStatement yield
     syn keyword pythonLambdaExpr lambda
     syn keyword pythonStatement with as
+    syn keyword pythonStatement async await
 
     syn keyword pythonStatement def nextgroup=pythonFunction skipwhite
     syn match pythonFunction "\%(\%(def\s\|@\)\s*\)\@<=\h\%(\w\|\.\)*" contained nextgroup=pythonVars


### PR DESCRIPTION
Highlight them and fix folding of "async def" functions